### PR TITLE
resolved issues with max_cpu

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM knowengdev/base_image:09_19_2017
+FROM knowengdev/base_image:08_01_2018
 LABEL Xi Chen="xichen24@illinois.edu" \
       Jing Ge="jingge2@illinois.edu" \
       Dan Lanier="lanier4@illinois.edu" \
@@ -8,7 +8,6 @@ ENV SRC_LOC /home
 
 # Install the latest knpackage
 RUN pip3 install -I knpackage redis
-RUN pip3 install -I numpy==1.15.4 pandas==0.23.4
 
 
 # Clone from github

--- a/src/gene_prioritization_toolbox.py
+++ b/src/gene_prioritization_toolbox.py
@@ -38,22 +38,13 @@ def run_correlation(run_parameters):
     len_phenotype = len(phenotype_df.index)
     array_of_jobs = range(0, len_phenotype)
 
-    if (len_phenotype <= max_cpu):
-        jobs_id = array_of_jobs
+    for i in range(0, len_phenotype, max_cpu):
+        jobs_id = array_of_jobs[i:i + max_cpu]
         number_of_jobs = len(jobs_id)
-        # -----------------------------------------------------------------------------------------
-        zipped_arguments = dstutil.zip_parameters(run_parameters, spreadsheet_df, phenotype_df, jobs_id)
-        dstutil.parallelize_processes_locally(run_correlation_worker, zipped_arguments, number_of_jobs)
-        write_phenotype_data_all(run_parameters)
-        # -----------------------------------------------------------------------------------------
-    else:
-        for i in range(0, len_phenotype, max_cpu):
-            jobs_id = array_of_jobs[i:i + max_cpu]
-            number_of_jobs = len(jobs_id)
-            #-----------------------------------------------------------------------------------------
-            zipped_arguments = dstutil.zip_parameters( run_parameters, spreadsheet_df, phenotype_df, jobs_id)
-            dstutil.parallelize_processes_locally( run_correlation_worker, zipped_arguments, number_of_jobs)
-            #-----------------------------------------------------------------------------------------
+        #-----------------------------------------------------------------------------------------
+        zipped_arguments = dstutil.zip_parameters( run_parameters, spreadsheet_df, phenotype_df, jobs_id)
+        dstutil.parallelize_processes_locally( run_correlation_worker, zipped_arguments, number_of_jobs)
+        #-----------------------------------------------------------------------------------------
     write_phenotype_data_all(run_parameters)
 
     kn.remove_dir           (results_tmp_directory)
@@ -136,8 +127,8 @@ def run_bootstrap_correlation(run_parameters):
     len_phenotype = len(phenotype_df.index)
     array_of_jobs = range(0, len_phenotype)
 
-    if (len_phenotype <= max_cpu):
-        jobs_id = array_of_jobs
+    for i in range(0, len_phenotype, max_cpu):
+        jobs_id = array_of_jobs[i:i + max_cpu]
         number_of_jobs = len(jobs_id)
         #-----------------------------------------------------------------------------------------
         zipped_arguments      = dstutil.zip_parameters( run_parameters
@@ -148,25 +139,8 @@ def run_bootstrap_correlation(run_parameters):
                                                       )
 
         dstutil.parallelize_processes_locally(run_bootstrap_correlation_worker, zipped_arguments, number_of_jobs)
-    
-        write_phenotype_data_all(run_parameters       )
         #-----------------------------------------------------------------------------------------
-
-    else:
-        for i in range(0, len_phenotype, max_cpu):
-            jobs_id = array_of_jobs[i:i + max_cpu]
-            number_of_jobs = len(jobs_id)
-            #-----------------------------------------------------------------------------------------
-        zipped_arguments      = dstutil.zip_parameters( run_parameters
-                                                      , spreadsheet_df
-                                                      , phenotype_df
-                                                      , n_bootstraps
-                                                      , jobs_id
-                                                      )
-
-        dstutil.parallelize_processes_locally(run_bootstrap_correlation_worker, zipped_arguments, number_of_jobs)
     write_phenotype_data_all(run_parameters)
-            #-----------------------------------------------------------------------------------------
 
 
 
@@ -274,29 +248,16 @@ def run_net_correlation(run_parameters):
     len_phenotype = len(phenotype_df.index)
     array_of_jobs = range(0, len_phenotype)
 
-    if (len_phenotype <= max_cpu):
-        jobs_id = array_of_jobs
+    for i in range(0, len_phenotype, max_cpu):
+        jobs_id = array_of_jobs[i:i + max_cpu]
         number_of_jobs = len(jobs_id)
-
+        #-----------------------------------------------------------------------------------------
         zipped_arguments = dstutil.zip_parameters(run_parameters, spreadsheet_df, phenotype_df, network_mat,
                                                   spreadsheet_genes_as_input, baseline_array, jobs_id)
         dstutil.parallelize_processes_locally(run_net_correlation_worker, zipped_arguments, number_of_jobs)
-
-        write_phenotype_data_all(run_parameters)
 
         #-----------------------------------------------------------------------------------------
-    else:
-        for i in range(0, len_phenotype, max_cpu):
-            jobs_id = array_of_jobs[i:i + max_cpu]
-            number_of_jobs = len(jobs_id)
-            #-----------------------------------------------------------------------------------------
-        zipped_arguments = dstutil.zip_parameters(run_parameters, spreadsheet_df, phenotype_df, network_mat,
-                                                  spreadsheet_genes_as_input, baseline_array, jobs_id)
-        dstutil.parallelize_processes_locally(run_net_correlation_worker, zipped_arguments, number_of_jobs)
-
-
     write_phenotype_data_all(run_parameters)
-            #-----------------------------------------------------------------------------------------
 
 
 
@@ -382,26 +343,16 @@ def run_bootstrap_net_correlation(run_parameters):
     len_phenotype = len(phenotype_df.index)
     array_of_jobs = range(0, len_phenotype)
 
-    if (len_phenotype <= max_cpu):
-        jobs_id = array_of_jobs
+    for i in range(0, len_phenotype, max_cpu):
+        jobs_id = array_of_jobs[i:i + max_cpu]
         number_of_jobs = len(jobs_id)
-        # -----------------------------------------------------------------------------------------
+        #-----------------------------------------------------------------------------------------
         zipped_arguments = dstutil.zip_parameters(run_parameters, spreadsheet_df, phenotype_df, network_mat,
                                                   spreadsheet_genes_as_input, baseline_array, jobs_id)
-        dstutil.parallelize_processes_locally(run_bootstrap_net_correlation_worker, zipped_arguments, number_of_jobs)
-        write_phenotype_data_all(run_parameters)
-        # -----------------------------------------------------------------------------------------
-    else:
-        for i in range(0, len_phenotype, max_cpu):
-            jobs_id = array_of_jobs[i:i + max_cpu]
-            number_of_jobs = len(jobs_id)
-            #-----------------------------------------------------------------------------------------
-            zipped_arguments = dstutil.zip_parameters(run_parameters, spreadsheet_df, phenotype_df, network_mat,
-                                                      spreadsheet_genes_as_input, baseline_array, jobs_id)
-            dstutil.parallelize_processes_locally(run_bootstrap_net_correlation_worker, zipped_arguments,
-                                                  number_of_jobs)
+        dstutil.parallelize_processes_locally(run_bootstrap_net_correlation_worker, zipped_arguments,
+                                              number_of_jobs)
+        #-----------------------------------------------------------------------------------------
     write_phenotype_data_all(run_parameters)
-            #-----------------------------------------------------------------------------------------
 
 
     kn.remove_dir(run_parameters["results_tmp_directory"])


### PR DESCRIPTION
These changes resolve the remaining issues with the max_cpu parameter.

I ran `make run_all_methods` with this version and confirmed all output files were identical to those produced by knowengdev/gene_prioritization_pipeline:02_20_2018, which is the version currently used in production and which predates all max_cpu changes.

Note that running `make run_all_methods` in this version does result in warnings:

```
python3 ../src/gene_prioritization.py -run_directory ./run_dir -run_file TEST_4_GP_many_drugs_t_test.yml
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:3157: RuntimeWarning: Degrees of freedom <= 0 for slice
  **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:130: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:2920: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:78: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:110: RuntimeWarning: invalid value encountered in true_divide
  arrmean, rcount, out=arrmean, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:3157: RuntimeWarning: Degrees of freedom <= 0 for slice
  **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:130: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:3157: RuntimeWarning: Degrees of freedom <= 0 for slice
  **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:130: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:3157: RuntimeWarning: Degrees of freedom <= 0 for slice
  **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:130: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:2920: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:78: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:110: RuntimeWarning: invalid value encountered in true_divide
  arrmean, rcount, out=arrmean, casting='unsafe', subok=False)
/usr/local/lib/python3.4/dist-packages/numpy/core/fromnumeric.py:3157: RuntimeWarning: Degrees of freedom <= 0 for slice
  **kwargs)
/usr/local/lib/python3.4/dist-packages/numpy/core/_methods.py:130: RuntimeWarning: invalid value encountered in true_divide
  ret, rcount, out=ret, casting='unsafe', subok=False)
```

I assume that because the outputs are identical to those produced in the production image, the underlying issue wasn't introduced by my changes; it's just that the updated versions of pandas and/or numpy are more verbose.  

Also note that `make unit_tests` fails in both this new version and in the reference version:

```
root@38bbd981894a:/home/test# make unit_test_setup
mkdir -p ./unit/tmp
root@38bbd981894a:/home/test# make unit_tests
cd unit; make all_unit_tests
make[1]: Entering directory `/home/test/unit'
PYTHONPATH='../../src/' python3 -m unittest discover --pattern=test_*.py
.F.
======================================================================
FAIL: test_get_t_test_correlation (test_get_t_test_correlation.TestGet_t_test_correlation)
check t_test against hand calculated value, and check that return values are real numbers
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/test/unit/test_get_t_test_correlation.py", line 44, in test_get_t_test_correlation
    self.assertTrue(np.isfinite(corr_arr[k]), msg='t_test Correlation Array is Not Finite')
AssertionError: False is not true : t_test Correlation Array is Not Finite

----------------------------------------------------------------------
Ran 3 tests in 0.007s

FAILED (failures=1)
make[1]: *** [all_unit_tests] Error 1
make[1]: Leaving directory `/home/test/unit'
make: *** [unit_tests] Error 2
```